### PR TITLE
Fix for incorrect hostile mob blocking (fix boolean short circuit)

### DIFF
--- a/src/main/java/dev/array21/harotorch/events/CreatureSpawnEventListener.java
+++ b/src/main/java/dev/array21/harotorch/events/CreatureSpawnEventListener.java
@@ -48,13 +48,13 @@ public class CreatureSpawnEventListener implements Listener {
 		
 			//Check if the spawned Entity is a Monster, Phantom, Slime, Ghast or Magma cube and not a Wither
 			// https://github.com/TheDutchMC/HaroTorch/issues/5
-			if(e instanceof Monster 
+			if((e instanceof Monster 
 					|| et.equals(EntityType.PHANTOM) 
 					|| et.equals(EntityType.SLIME) 
 					|| et.equals(EntityType.GHAST)
-					|| et.equals(EntityType.MAGMA_CUBE)
-					&& !et.equals(EntityType.WITHER) 
-					&& !et.equals(EntityType.ENDER_DRAGON)) {
+					|| et.equals(EntityType.MAGMA_CUBE))
+					&& (!et.equals(EntityType.WITHER) 
+					&& !et.equals(EntityType.ENDER_DRAGON))) {
 				
 				if(torchInRange(event.getLocation())) {
 					event.setCancelled(true);


### PR DESCRIPTION
Fixes boolean short circuit by grouping together the logical checks. Could also be fixed by using the non short cicuit counter parts of `|` and `&` respectively.

Tested and the changes appear working by now correctly blocking Guardians. Other hostile mobs are still blocked (including slime) and non-hostile mobs are also allowed wtih 'onlyBlockHostile' enabled